### PR TITLE
word-break on map

### DIFF
--- a/jmap.js
+++ b/jmap.js
@@ -812,7 +812,10 @@
             var prefDiv = $('<div>')
                 .data('data', pref)
                 .addClass(params.prefectureClass)
-                .attr('jmap-uniq', pref.code);
+                .attr('jmap-uniq', pref.code)
+                .css({
+                    'word-break': 'break-all'
+                });
 
             // Prefecture Inner
             if (params.showPrefectureName && !option.name) {


### PR DESCRIPTION
When making browswer small, some prefecture names can't be seen on map. So, I added word-break style.